### PR TITLE
Introducing a field skip_timestamp to allow output to not contain timestamp

### DIFF
--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -54,9 +54,14 @@ func Query(ctx context.Context, api v1.API, args *QueryArgs, pq *QueryParams, sk
 	case result.Type() == model.ValVector:
 		samples := result.(model.Vector)
 		for _, sample := range samples {
-			fmt.Printf("[%s] %s = %v\n",
-				sample.Timestamp.Time().Format("Jan 2 15:04:05 -0700 MST"),
-				sample.Metric.String(), sample.Value)
+			if !*skipTimestamp {
+				fmt.Printf("[%s] %s = %v\n",
+					sample.Timestamp.Time().Format("Jan 2 15:04:05 -0700 MST"),
+					sample.Metric.String(), sample.Value)
+			} else {
+				fmt.Printf("%s = %v\n",
+					sample.Metric.String(), sample.Value)
+			}
 		}
 	case result.Type() == model.ValMatrix:
 		streams := result.(model.Matrix)

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -23,7 +23,7 @@ type QueryParams struct {
 //
 // Perform a PromQL query and print the results
 //
-func Query(ctx context.Context, api v1.API, args *QueryArgs, pq *QueryParams) {
+func Query(ctx context.Context, api v1.API, args *QueryArgs, pq *QueryParams, skipTimestamp *bool) {
 	var result model.Value
 	var warnings v1.Warnings
 	var err error
@@ -63,9 +63,15 @@ func Query(ctx context.Context, api v1.API, args *QueryArgs, pq *QueryParams) {
 		for _, stream := range streams {
 			fmt.Printf("%s = \n", stream.Metric.String())
 			for _, val := range stream.Values {
-				fmt.Printf("\t[%s] %v\n",
-					val.Timestamp.Time().Format("Jan 2 15:04:05 -0700 MST"),
-					val.Value)
+				if !*skipTimestamp {
+					fmt.Printf("\t[%s] %v\n",
+						val.Timestamp.Time().Format("Jan 2 15:04:05 -0700 MST"),
+						val.Value)
+				} else {
+					fmt.Printf("\t%v\n",
+						val.Value)
+				}
+
 			}
 		}
 	case result.Type() == model.ValScalar:

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 	len := flag.String("len", "", "Length of query range")
 	step := flag.String("step", "1m", "Range resolution")
 	timed := flag.Bool("timed", false, "Show query time")
+	skipTimestamp := flag.Bool("skip_timestamp", false, "Skip timestamp in range query")
 	active := flag.Bool("active", false, "only display active targets")
 	down := flag.Bool("down", false, "only display active targets that are down (implies -active)")
 	count := flag.Bool("count", false, "only display a count of the requested items")
@@ -157,7 +158,7 @@ func main() {
 			}
 		}
 		args := query.QueryArgs{Timed: *timed}
-		query.Query(ctx, api, &args, &pq)
+		query.Query(ctx, api, &args, &pq, skipTimestamp)
 	case "runtime":
 		runtime.Runtime(ctx, api)
 	case "rules":

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 	len := flag.String("len", "", "Length of query range")
 	step := flag.String("step", "1m", "Range resolution")
 	timed := flag.Bool("timed", false, "Show query time")
-	skipTimestamp := flag.Bool("skip_timestamp", false, "Skip timestamp in range query")
+	skipTimestamp := flag.Bool("skip_timestamp", false, "Skip timestamp in query output")
 	active := flag.Bool("active", false, "only display active targets")
 	down := flag.Bool("down", false, "only display active targets that are down (implies -active)")
 	count := flag.Bool("count", false, "only display a count of the requested items")


### PR DESCRIPTION
Without skip_timestamp

```
shchellappa@shchellappa-lt:/mnt/c/GitFolder/promclient_2/promclient$ ./promclient -promurl=https://127.0.0.1:9090 -insecure -command=query -query='(increase(ALERTS{alertstate="firing", namespace="nid-data-importer"}[60s]))'
[Mar 31 10:52:26 -0700 PDT] {alertname="KubeDaemonSetRolloutStuck", alertstate="firing", container="kube-state-metrics", daemonset="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/4XuMd2Iiz/cluster-overview?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="kube-state-metrics-6d4cc66c89-vzjwm", service="kube-state-metrics", severity="minor"} = 0
[Mar 31 10:52:26 -0700 PDT] {alertname="KubeDaemonSetRolloutStuck", alertstate="firing", container="kube-state-metrics", daemonset="nidavellir-data-importer", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/4XuMd2Iiz/cluster-overview?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="kube-state-metrics-6d4cc66c89-vzjwm", service="kube-state-metrics", severity="minor"} = 0
[Mar 31 10:52:26 -0700 PDT] {alertname="KubePodCrashLooping", alertstate="firing", container="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/882BBBA9-BCE3-428F-AE61-A6A765B73BE8/kubernetes-nodes?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="dragonfly-supernode-6h2mb", reason="CrashLoopBackOff", service="kube-state-metrics", severity="minor", uid="2cf372e3-0b4f-443c-b84a-dfcd78a45d73"} = 0
[Mar 31 10:52:26 -0700 PDT] {alertname="KubePodCrashLooping", alertstate="firing", container="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/882BBBA9-BCE3-428F-AE61-A6A765B73BE8/kubernetes-nodes?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="dragonfly-supernode-fx4db", reason="CrashLoopBackOff", service="kube-state-metrics", severity="minor", uid="86a0e29a-f944-465b-b372-3f68105b1e73"} = 0
[Mar 31 10:52:26 -0700 PDT] {alertname="KubePodCrashLooping", alertstate="firing", container="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/882BBBA9-BCE3-428F-AE61-A6A765B73BE8/kubernetes-nodes?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="dragonfly-supernode-vtcm5", reason="CrashLoopBackOff", service="kube-state-metrics", severity="minor", uid="54b88b14-a208-4e50-93aa-5a68c374b8cd"} = 0


shchellappa@shchellappa-lt:/mnt/c/GitFolder/promclient_2/promclient$ ./promclient -promurl=https://127.0.0.1:9090 -insecure -command=query -query='ALERTS{alertstate="firing", namespace="nid-data-importer"}[60s]'
ALERTS{alertname="KubeDaemonSetRolloutStuck", alertstate="firing", container="kube-state-metrics", daemonset="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/4XuMd2Iiz/cluster-overview?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="kube-state-metrics-6d4cc66c89-vzjwm", service="kube-state-metrics", severity="minor"} =
        [Mar 31 10:52:21 -0700 PDT] 1
        [Mar 31 10:52:51 -0700 PDT] 1
ALERTS{alertname="KubeDaemonSetRolloutStuck", alertstate="firing", container="kube-state-metrics", daemonset="nidavellir-data-importer", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/4XuMd2Iiz/cluster-overview?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="kube-state-metrics-6d4cc66c89-vzjwm", service="kube-state-metrics", severity="minor"} =
        [Mar 31 10:52:21 -0700 PDT] 1
        [Mar 31 10:52:51 -0700 PDT] 1
ALERTS{alertname="KubePodCrashLooping", alertstate="firing", container="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/882BBBA9-BCE3-428F-AE61-A6A765B73BE8/kubernetes-nodes?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="dragonfly-supernode-6h2mb", reason="CrashLoopBackOff", service="kube-state-metrics", severity="minor", uid="2cf372e3-0b4f-443c-b84a-dfcd78a45d73"} =
        [Mar 31 10:52:21 -0700 PDT] 1
        [Mar 31 10:52:51 -0700 PDT] 1
ALERTS{alertname="KubePodCrashLooping", alertstate="firing", container="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/882BBBA9-BCE3-428F-AE61-A6A765B73BE8/kubernetes-nodes?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="dragonfly-supernode-fx4db", reason="CrashLoopBackOff", service="kube-state-metrics", severity="minor", uid="86a0e29a-f944-465b-b372-3f68105b1e73"} =
        [Mar 31 10:52:21 -0700 PDT] 1
        [Mar 31 10:52:51 -0700 PDT] 1
ALERTS{alertname="KubePodCrashLooping", alertstate="firing", container="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/882BBBA9-BCE3-428F-AE61-A6A765B73BE8/kubernetes-nodes?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="dragonfly-supernode-vtcm5", reason="CrashLoopBackOff", service="kube-state-metrics", severity="minor", uid="54b88b14-a208-4e50-93aa-5a68c374b8cd"} =
        [Mar 31 10:52:21 -0700 PDT] 1
        [Mar 31 10:52:51 -0700 PDT] 1


```
With skip_timestamp

```
shchellappa@shchellappa-lt:/mnt/c/GitFolder/promclient_2/promclient$ ./promclient -promurl=https://127.0.0.1:9090 -insecure -command=query -query='(increase(ALERTS{alertstate="firing", namespace="nid-data-importer"}[60s]))' -skip_timestamp
{alertname="KubeDaemonSetRolloutStuck", alertstate="firing", container="kube-state-metrics", daemonset="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/4XuMd2Iiz/cluster-overview?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="kube-state-metrics-6d4cc66c89-vzjwm", service="kube-state-metrics", severity="minor"} = 0
{alertname="KubeDaemonSetRolloutStuck", alertstate="firing", container="kube-state-metrics", daemonset="nidavellir-data-importer", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/4XuMd2Iiz/cluster-overview?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="kube-state-metrics-6d4cc66c89-vzjwm", service="kube-state-metrics", severity="minor"} = 0
{alertname="KubePodCrashLooping", alertstate="firing", container="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/882BBBA9-BCE3-428F-AE61-A6A765B73BE8/kubernetes-nodes?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="dragonfly-supernode-6h2mb", reason="CrashLoopBackOff", service="kube-state-metrics", severity="minor", uid="2cf372e3-0b4f-443c-b84a-dfcd78a45d73"} = 0
{alertname="KubePodCrashLooping", alertstate="firing", container="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/882BBBA9-BCE3-428F-AE61-A6A765B73BE8/kubernetes-nodes?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="dragonfly-supernode-fx4db", reason="CrashLoopBackOff", service="kube-state-metrics", severity="minor", uid="86a0e29a-f944-465b-b372-3f68105b1e73"} = 0
{alertname="KubePodCrashLooping", alertstate="firing", container="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/882BBBA9-BCE3-428F-AE61-A6A765B73BE8/kubernetes-nodes?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="dragonfly-supernode-vtcm5", reason="CrashLoopBackOff", service="kube-state-metrics", severity="minor", uid="54b88b14-a208-4e50-93aa-5a68c374b8cd"} = 0


shchellappa@shchellappa-lt:/mnt/c/GitFolder/promclient_2/promclient$ ./promclient -promurl=https://127.0.0.1:9090 -insecure -command=query -query='ALERTS{alertstate="firing", namespace="nid-data-importer"}[60s]' -skip_timestamp
ALERTS{alertname="KubeDaemonSetRolloutStuck", alertstate="firing", container="kube-state-metrics", daemonset="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/4XuMd2Iiz/cluster-overview?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="kube-state-metrics-6d4cc66c89-vzjwm", service="kube-state-metrics", severity="minor"} =
        1
        1
ALERTS{alertname="KubeDaemonSetRolloutStuck", alertstate="firing", container="kube-state-metrics", daemonset="nidavellir-data-importer", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/4XuMd2Iiz/cluster-overview?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="kube-state-metrics-6d4cc66c89-vzjwm", service="kube-state-metrics", severity="minor"} =
        1
        1
ALERTS{alertname="KubePodCrashLooping", alertstate="firing", container="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/882BBBA9-BCE3-428F-AE61-A6A765B73BE8/kubernetes-nodes?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="dragonfly-supernode-6h2mb", reason="CrashLoopBackOff", service="kube-state-metrics", severity="minor", uid="2cf372e3-0b4f-443c-b84a-dfcd78a45d73"} =
        1
        1
ALERTS{alertname="KubePodCrashLooping", alertstate="firing", container="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/882BBBA9-BCE3-428F-AE61-A6A765B73BE8/kubernetes-nodes?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="dragonfly-supernode-fx4db", reason="CrashLoopBackOff", service="kube-state-metrics", severity="minor", uid="86a0e29a-f944-465b-b372-3f68105b1e73"} =
        1
        1
ALERTS{alertname="KubePodCrashLooping", alertstate="firing", container="dragonfly-supernode", dashboard="https://ngn-grafana.thanos.nvidiangn.net/d/882BBBA9-BCE3-428F-AE61-A6A765B73BE8/kubernetes-nodes?var-datacenter=ND-SJC6W-DC", endpoint="https-main", instance="10.192.6.19:8081", job="kube-state-metrics", namespace="nid-data-importer", pduuid="PFEZ7F1", pod="dragonfly-supernode-vtcm5", reason="CrashLoopBackOff", service="kube-state-metrics", severity="minor", uid="54b88b14-a208-4e50-93aa-5a68c374b8cd"} =
        1
        1

```

This parameter is created with the intention of using for both range and instant queries although it may be be more useful for range queries.